### PR TITLE
Fixed caching of unformatted balance

### DIFF
--- a/bismuthclient/bismuthclient/bismuthclient.py
+++ b/bismuthclient/bismuthclient/bismuthclient.py
@@ -205,15 +205,14 @@ class BismuthClient():
         if not self.address or not self._wallet:
             return 'N/A'
         try:
-            cached = self._get_cached('balance')
-            if cached:
-                return cached
-            balance = self.command("balanceget", [self.address])
-            balance = balance[0]
-            self._set_cache('balance', balance)
-        except:
-            # TODO: Handle retry, at least error message.
-            balance = 'N/A'
+            balance = self._get_cached('balance')
+            if not balance:
+                balance = self.command("balanceget", [self.address])[0]
+                self._set_cache('balance', balance)
+                balance = self._get_cached('balance')
+        except Exception as e:
+            self.app_log.error(e)
+            return 'N/A'
         if for_display:
             balance = AmountFormatter(balance).to_string(leading=0)
         if balance == '0E-8':

--- a/bismuthclient/bismuthclient/bismuthclient.py
+++ b/bismuthclient/bismuthclient/bismuthclient.py
@@ -166,7 +166,7 @@ class BismuthClient():
         for entry in scandir(scan_dir):
             # print(entry)
             if entry.name.endswith('.der') and entry.is_file():
-                 wallets.append(self._wallet.wallet_preview(entry.path))
+                wallets.append(self._wallet.wallet_preview(entry.path))
         # TODO: sorts by name
         return wallets
 

--- a/bismuthclient/bismuthclient/bismuthclient.py
+++ b/bismuthclient/bismuthclient/bismuthclient.py
@@ -82,7 +82,7 @@ class BismuthClient():
             with open(filename) as f:
                 self._alias_cache = json.load(f)
 
-    def get_aliases_of(self, addresses: list) -> list:
+    def get_aliases_of(self, addresses: list) -> dict:
         """Get alias from a list of addresses. returns a dict {address:alias (or '')}"""
         # Filter out the ones from valid cache
         now = time()


### PR DESCRIPTION
I don't mind if you don't merge it and fix it in some other way but please fix the caching of the raw balance since it's annoying in Tornado Wallet :-)

The second time `balance()` is called it returns the raw unformatted value because it was cached before it was formatted.