### PR TITLE
Fix ValueError: could not convert string to float: 'N/A'

### DIFF
--- a/bismuthclient/bismuthclient/bismuthclient.py
+++ b/bismuthclient/bismuthclient/bismuthclient.py
@@ -235,7 +235,7 @@ class BismuthClient():
             balance = balance[0]
         except:
             # TODO: Handle retry, at least error message.
-            balance = 'N/A'
+            return 'N/A'
         if for_display:
             balance = AmountFormatter(balance).to_string(leading=0)
         if balance == '0E-8':


### PR DESCRIPTION
If you for some reason end up in `except`, you assign `'N/A'` to `balance` but then if `for_display` is `True`, you try to convert `balance` to `float` in `AmountFormatter`. And that won't end well.